### PR TITLE
添加对浏览器扩展程序的支持

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -49,7 +49,7 @@ export class ConsoleBan {
 
   debug() {
     if (this._debug) {
-      const db = new Function('debugger')
+      const db = function() { debugger }
       setInterval(db, this._debugTime)
     }
   }
@@ -87,7 +87,7 @@ export class ConsoleBan {
       const isOpen = (): boolean => {
         return this._evalCounts === (this._isOpenedEver ? 1 : 2)
       }
-      const watchElement = new Function()
+      const watchElement = function() {}
       watchElement.toString = (): string => {
         this._evalCounts++
         if (isOpen()) {


### PR DESCRIPTION
浏览器扩展程序[默认的内容安全策略](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_Security_Policy#eval()_and_friends)不能使用 `eval` 或 `new Function`，所以我将代码里的 `new Function` 替换成了函数字面量。